### PR TITLE
fix: exported types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,6 @@
 import {
   FastifyPluginCallback,
-  FastifyPluginAsync,
-} from 'fastify'
+} from 'fastify-plugin'
 
 export interface TrapsPluginOptions {
   timeout?: number,
@@ -12,7 +11,5 @@ export interface TrapsPluginOptions {
   strict?: boolean
 }
 
-export const trapsPluginCallback: FastifyPluginCallback<TrapsPluginOptions>;
-export const trapsPluginAsync: FastifyPluginAsync<TrapsPluginOptions>;
-
-export default trapsPluginCallback;
+const plugin: FastifyPluginCallback<TrapsPluginOptions>;
+export = plugin;

--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ function plugin (fastify, opts, next) {
     return next(new TypeError(`timeout must be a number, received ${typeof config.timeout}`))
   }
   if (config.timeout < 1) {
-    return next(new RangeError(`timeout must be greather than 0, received ${config.timeout}`))
+    return next(new RangeError(`timeout must be greater than 0, received ${config.timeout}`))
   }
   if (typeof config.strict !== 'boolean') {
     return next(new TypeError(`strict must be a boolean, received ${typeof config.strict}`))

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -42,7 +42,7 @@ test('invalid options', async t => {
       opts: {
         timeout: 0
       },
-      error: new RangeError('timeout must be greather than 0, received 0')
+      error: new RangeError('timeout must be greater than 0, received 0')
     },
     {
       opts: {


### PR DESCRIPTION
Doesn't migrate to ESM, but fixes the exported module types instead.

Resolves #284